### PR TITLE
security: Delay dependabot updates [TAROT-3707]

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,12 +1,14 @@
 version: 2
 updates:
-- package-ecosystem: npm
-  directory: "/"
-  schedule:
-    interval: daily
-    timezone: Europe/Lisbon
-  open-pull-requests-limit: 10
-  ignore:
-  - dependency-name: jscpd
-    versions:
-    - 3.3.24
+  - package-ecosystem: npm
+    directory: "/"
+    schedule:
+      interval: daily
+      timezone: Europe/Lisbon
+    open-pull-requests-limit: 10
+    ignore:
+      - dependency-name: jscpd
+        versions:
+          - 3.3.24
+    cooldown:
+      default-days: 7


### PR DESCRIPTION
7 days should be enough when most malicious packages are patched within 24 hours.